### PR TITLE
Add team sales dashboard

### DIFF
--- a/frontend/src/pages/team/TeamSales.js
+++ b/frontend/src/pages/team/TeamSales.js
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { Card, Stack, Container, Typography } from '@mui/material';
+import { DataGrid } from '@mui/x-data-grid';
+import { useParams } from 'react-router-dom';
+import { apiget } from '../../service/api';
+import TableStyle from '../../components/TableStyle';
+
+export default function TeamSales() {
+  const { teamId } = useParams();
+  const [sales, setSales] = useState([]);
+
+  const fetchData = async () => {
+    const result = await apiget(`policy/sales/team/${teamId}`);
+    if (result && result.status === 200) {
+      setSales(result?.data?.sales);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, [teamId]);
+
+  const columns = [
+    { field: 'name', headerName: 'Agent', flex: 1 },
+    { field: 'policies', headerName: 'Policies Sold', flex: 1 }
+  ];
+
+  return (
+    <Container>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" mb={5}>
+        <Typography variant="h4">Team Sales</Typography>
+      </Stack>
+      <TableStyle>
+        <Card style={{ height: '500px', paddingTop: '15px' }}>
+          <DataGrid rows={sales} columns={columns} getRowId={(row) => row.userId} />
+        </Card>
+      </TableStyle>
+    </Container>
+  );
+}

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -20,6 +20,7 @@ import Meeting from './pages/meeting/Meeting';
 import MeetingView from './pages/meeting/View'
 import Email from './pages/email/Email'
 import EmailView from './pages/email/View'
+import TeamSales from './pages/team/TeamSales'
 import Task from './pages/task/Task';
 import TaskView from './pages/task/View'
 import EmailTemplate from './pages/emailTemplate/EmailTemplate';
@@ -57,6 +58,7 @@ export default function Router() {
         { path: 'emailtemplate', element: <EmailTemplate /> },
         { path: 'emailtemplate/add', element: <AddEmailTemplate /> },
         { path: 'emailtemplate/view/:id', element: <ViewEmailTemplate /> },
+        { path: 'team/:teamId/sales', element: <TeamSales /> },
         // { path: 'history', element: <History /> },
         
         // { path: '*', element: <Navigate to="/dashboard/app" /> },

--- a/server/controllers/team.js
+++ b/server/controllers/team.js
@@ -1,0 +1,34 @@
+import Team from '../model/Team';
+import User from '../model/User';
+
+const add = async (req, res) => {
+    try {
+        const team = new Team(req.body);
+        await team.save();
+        res.status(201).json({ team, message: 'Team created successfully' });
+    } catch (err) {
+        res.status(500).json({ message: 'Failed to create team' });
+    }
+};
+
+const list = async (req, res) => {
+    try {
+        const teams = await Team.find().populate('members', 'firstName lastName');
+        res.status(200).json({ teams });
+    } catch (err) {
+        res.status(500).json({ message: 'Failed to fetch teams' });
+    }
+};
+
+const assign = async (req, res) => {
+    try {
+        const { teamId, userId } = req.params;
+        await User.findByIdAndUpdate(userId, { team: teamId });
+        await Team.findByIdAndUpdate(teamId, { $addToSet: { members: userId } });
+        res.status(200).json({ message: 'User assigned to team' });
+    } catch (err) {
+        res.status(500).json({ message: 'Failed to assign user' });
+    }
+};
+
+export default { add, list, assign };

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -23,6 +23,7 @@ const edit = async (req, res) => {
                     firstName: req.body.firstName,
                     lastName: req.body.lastName,
                     emailAddress: req.body.emailAddress,
+                    team: req.body.team,
                     modifiedOn: req.body.modifiedOn
                 }
             },
@@ -59,7 +60,7 @@ const deleteData = async (req, res) => {
 
 const register = async (req, res) => {
     try {
-        const { firstName, lastName, emailAddress, password } = req.body;
+        const { firstName, lastName, emailAddress, password, team } = req.body;
 
         // Check if the username is already taken
         const existingUser = await User.findOne({ emailAddress });
@@ -71,7 +72,7 @@ const register = async (req, res) => {
         const hashedPassword = await bcrypt.hash(password, 10);
 
         // Create a new user
-        const newUser = new User({ firstName, lastName, emailAddress, password: hashedPassword });
+        const newUser = new User({ firstName, lastName, emailAddress, password: hashedPassword, team });
         await newUser.save();
 
         res.status(201).json({ message: 'User created successfully' });

--- a/server/model/Team.js
+++ b/server/model/Team.js
@@ -1,0 +1,12 @@
+import mongoose from "mongoose";
+
+const Team = new mongoose.Schema({
+    name: { type: String, required: true },
+    description: { type: String },
+    members: [{ type: mongoose.Schema.ObjectId, ref: 'User' }],
+    createdBy: { type: mongoose.Schema.ObjectId, ref: 'User' },
+    createdOn: { type: Date, default: Date.now },
+    modifiedOn: { type: Date, default: Date.now }
+})
+
+export default mongoose.model('Team', Team);

--- a/server/model/User.js
+++ b/server/model/User.js
@@ -8,6 +8,10 @@ const User = new mongoose.Schema({
     role: {
         type: String, enum: ['user', 'admin'], default: 'user'
     },
+    team: {
+        type: mongoose.Schema.ObjectId,
+        ref: 'Team'
+    },
     deleted: {
         type: Boolean,
         default: false,

--- a/server/routes/policyRoutes.js
+++ b/server/routes/policyRoutes.js
@@ -10,6 +10,6 @@ router.get('/view/:id', auth,Policy.view)
 router.put('/edit/:id', auth,Policy.edit)
 router.delete('/delete/:id', auth,Policy.deleteData)
 router.post('/deletemany', auth, Policy.deleteMany)
+router.get('/sales/team/:teamId', auth, Policy.salesByTeam)
 
-
-export default router
+export default router;

--- a/server/routes/serverRoutes.js
+++ b/server/routes/serverRoutes.js
@@ -14,6 +14,7 @@ import PolicyRoute from "./policyRoutes"
 import DocumentRoute from './documentRoutes'
 import PolicyDocumentRoute from './policyDocumentRoutes'
 import emailTemmplateRoute from './emailTemplateRoutes'
+import TeamRoute from './teamRoutes'
 
 router.use('/lead', LeadRoute);
 router.use('/contact', ContactRoute);
@@ -28,5 +29,6 @@ router.use('/policy', PolicyRoute)
 router.use('/document', DocumentRoute)
 router.use('/policydocument', PolicyDocumentRoute)
 router.use('/emailtemplate', emailTemmplateRoute)
+router.use('/team', TeamRoute)
 
 export default router;

--- a/server/routes/teamRoutes.js
+++ b/server/routes/teamRoutes.js
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import Team from '../controllers/team';
+import auth from '../middlewares/auth';
+const router = Router();
+
+router.post('/add', auth, Team.add);
+router.get('/list', auth, Team.list);
+router.post('/assign/:teamId/:userId', auth, Team.assign);
+
+export default router;


### PR DESCRIPTION
## Summary
- introduce `Team` model and team management routes
- allow assigning users to teams
- compute policy sales totals per team
- add a `TeamSales` page and router entry
- expose API endpoint `/policy/sales/team/:teamId`

## Testing
- `npm test` in `server` *(fails: Error: no test specified)*
- `npm test --silent` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684708602158832ea96bee3b85dc48f8