### PR TITLE
Implement lead follow‑up features

### DIFF
--- a/server/controllers/calls.js
+++ b/server/controllers/calls.js
@@ -86,4 +86,17 @@ const deleteMany = async (req, res) => {
     }
 };
 
-export default { index, add, view, edit, deleteData, deleteMany }
+const stats = async (req, res) => {
+    try {
+        const filter = { deleted: false };
+        if (req.user && req.user._id) {
+            filter.createdBy = req.user._id;
+        }
+        const totalCalls = await Calls.countDocuments(filter);
+        res.status(200).json({ totalCalls });
+    } catch (err) {
+        res.status(500).json({ message: "Error calculating stats", error: err.message });
+    }
+};
+
+export default { index, add, view, edit, deleteData, deleteMany, stats }

--- a/server/controllers/leads.js
+++ b/server/controllers/leads.js
@@ -148,6 +148,29 @@ const view = async (req, res) => {
   }
 };
 
+const upcoming = async (req, res) => {
+  try {
+    const now = new Date();
+    const nextWeek = new Date();
+    nextWeek.setDate(now.getDate() + 7);
+
+    const filter = {
+      deleted: false,
+      nextContact: { $gte: now, $lte: nextWeek },
+    };
+
+    let leads = await Lead.find(filter).populate({
+      path: 'createdBy',
+      select: ['firstName', 'lastName']
+    });
+
+    res.status(200).json({ leads });
+  } catch (err) {
+    console.error('Failed to fetch upcoming leads:', err);
+    res.status(500).json({ message: 'Error fetching upcoming leads' });
+  }
+};
+
 
 const deleteData = async (req, res) => {
   try {
@@ -216,4 +239,4 @@ const deleteMany = async (req, res) => {
   }
 };
 
-export default { index, add, edit, view, deleteData, deleteMany }
+export default { index, add, edit, view, deleteData, deleteMany, upcoming }

--- a/server/model/Lead.js
+++ b/server/model/Lead.js
@@ -34,6 +34,12 @@ const Lead = new mongoose.Schema({
     conversionDateTime: { type: String },
     leadCategory: { type: String },
     leadPriority: { type: String },
+    nextContact: { type: Date },
+    temperature: {
+        type: String,
+        enum: ['Hot', 'Warm', 'Cold'],
+        default: 'Warm'
+    },
     contact_id: {
         type: mongoose.Schema.ObjectId,
         ref: "Contacts",

--- a/server/routes/callRoutes.js
+++ b/server/routes/callRoutes.js
@@ -1,14 +1,15 @@
 import { Router } from 'express';
 import Calls from '../controllers/calls';
-import auth from '../middlewares/auth'
+import auth from '../middlewares/auth';
+
 const router = Router();
 
-router.get('/list',auth, Calls.index)
-router.post('/add', auth,Calls.add)
-router.get('/view/:id', auth,Calls.view)
-router.put('/edit/:id', auth,Calls.edit)
-router.delete('/delete/:id', auth,Calls.deleteData)
-router.post('/deletemany', auth,Calls.deleteMany)
+router.get('/list', auth, Calls.index);
+router.post('/add', auth, Calls.add);
+router.get('/view/:id', auth, Calls.view);
+router.put('/edit/:id', auth, Calls.edit);
+router.delete('/delete/:id', auth, Calls.deleteData);
+router.post('/deletemany', auth, Calls.deleteMany);
+router.get('/stats', auth, Calls.stats);
 
-
-export default router
+export default router;

--- a/server/routes/leadRoutes.js
+++ b/server/routes/leadRoutes.js
@@ -1,16 +1,16 @@
 import { Router } from 'express';
-import Lead from '../controllers/leads'
-import auth from '../middlewares/auth'
-import { upload } from '../utils/upload'
+import Lead from '../controllers/leads';
+import auth from '../middlewares/auth';
+import { upload } from '../utils/upload';
 
 const router = Router();
 
-router.get('/list', auth, Lead.index)
-router.post('/add', auth, Lead.add)
-router.put('/edit/:id', auth, Lead.edit)
-router.get('/view/:id', auth, Lead.view)
-router.delete('/delete/:id', auth, Lead.deleteData)
-router.post('/deletemany', auth, Lead.deleteMany)
+router.get('/list', auth, Lead.index);
+router.post('/add', auth, Lead.add);
+router.put('/edit/:id', auth, Lead.edit);
+router.get('/view/:id', auth, Lead.view);
+router.delete('/delete/:id', auth, Lead.deleteData);
+router.post('/deletemany', auth, Lead.deleteMany);
+router.get('/upcoming', auth, Lead.upcoming);
 
-
-export default router
+export default router;


### PR DESCRIPTION
## Summary
- add nextContact and temperature fields to Lead model
- create call stats endpoint
- return upcoming leads within a week
- expose new API routes for stats and upcoming leads

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test` in frontend (fails: react-scripts not found)

------
https://chatgpt.com/codex/tasks/task_e_6847089abd10832ebf533117daa4cd7a