### PR TITLE
Add stats API with commission calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ InsurancePro is a cutting-edge Customer Relationship Management (CRM) platform t
 2. Lead Management: Seamlessly track leads and turn them into loyal clients.
 3. Policy Tracking: Keep tabs on policies, premiums, and renewals effortlessly.
 4. Customization: Tailor the CRM to your unique workflow and branding.
+5. Statistics & Salary Calculation: Automatic overview of calls, meetings,
+   sales and commission with daily, weekly and monthly progress, including a
+   motivational "value per call" metric.
 
 Ready to elevate your insurance business? Check out our Installation Guide to get started.
 

--- a/server/controllers/statistics.js
+++ b/server/controllers/statistics.js
@@ -1,0 +1,67 @@
+import Calls from "../model/Calls";
+import Meetings from "../model/Meetings";
+import Policy from "../model/policy";
+
+const COMMISSION_RATE = 0.1;
+
+const parsePremium = (val) => {
+  const num = parseFloat(val);
+  return Number.isNaN(num) ? 0 : num;
+};
+
+const getStats = async (startDate) => {
+  const callQuery = { deleted: false };
+  const meetingQuery = { deleted: false };
+  const policyQuery = { deleted: false };
+
+  if (startDate) {
+    callQuery.createdOn = { $gte: startDate };
+    meetingQuery.createdOn = { $gte: startDate };
+    policyQuery.createdOn = { $gte: startDate };
+  }
+
+  const [callCount, meetingCount, policies] = await Promise.all([
+    Calls.countDocuments(callQuery),
+    Meetings.countDocuments(meetingQuery),
+    Policy.find(policyQuery)
+  ]);
+
+  const commission = policies.reduce(
+    (sum, p) => sum + parsePremium(p.premiumAmount),
+    0
+  ) * COMMISSION_RATE;
+
+  const valuePerCall = callCount > 0 ? commission / callCount : 0;
+
+  return {
+    calls: callCount,
+    meetings: meetingCount,
+    sales: policies.length,
+    commission,
+    valuePerCall,
+  };
+};
+
+const overview = async (req, res) => {
+  try {
+    const now = new Date();
+    const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const startOfWeek = new Date(startOfDay);
+    startOfWeek.setDate(startOfDay.getDate() - startOfDay.getDay());
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+
+    const [total, daily, weekly, monthly] = await Promise.all([
+      getStats(),
+      getStats(startOfDay),
+      getStats(startOfWeek),
+      getStats(startOfMonth),
+    ]);
+
+    res.json({ total, daily, weekly, monthly });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Failed to fetch statistics" });
+  }
+};
+
+export default { overview };

--- a/server/routes/serverRoutes.js
+++ b/server/routes/serverRoutes.js
@@ -14,6 +14,7 @@ import PolicyRoute from "./policyRoutes"
 import DocumentRoute from './documentRoutes'
 import PolicyDocumentRoute from './policyDocumentRoutes'
 import emailTemmplateRoute from './emailTemplateRoutes'
+import StatsRoute from './statisticsRoutes'
 
 router.use('/lead', LeadRoute);
 router.use('/contact', ContactRoute);
@@ -28,5 +29,6 @@ router.use('/policy', PolicyRoute)
 router.use('/document', DocumentRoute)
 router.use('/policydocument', PolicyDocumentRoute)
 router.use('/emailtemplate', emailTemmplateRoute)
+router.use('/stats', StatsRoute)
 
 export default router;

--- a/server/routes/statisticsRoutes.js
+++ b/server/routes/statisticsRoutes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import Stats from '../controllers/statistics';
+import auth from '../middlewares/auth';
+
+const router = Router();
+
+router.get('/overview', auth, Stats.overview);
+
+export default router;


### PR DESCRIPTION
## Summary
- document new statistics and salary calculation feature
- add statistics controller and route
- wire stats endpoint into server routes

## Testing
- `npm test` in `server`
- `npm test --watchAll=false` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684708cd159c832eac8ad8ab7df05df2